### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/selenium_interface.py
+++ b/selenium_interface.py
@@ -9,6 +9,7 @@ import io
 import base64
 from dotenv import load_dotenv
 from deep_tree_echo import DeepTreeEcho, TreeNode
+from urllib.parse import urlparse
 
 # Create templates directory
 os.makedirs('templates', exist_ok=True)
@@ -309,7 +310,8 @@ class SeleniumInterface:
             try:
                 # Get current URL and check if we need to navigate
                 self.logger.info(f"Current URL before sending message: {self.page.url}")
-                if not self.page.url.startswith("https://chat.openai.com"):
+                parsed_url = urlparse(self.page.url)
+                if parsed_url.hostname != "chat.openai.com":
                     self.logger.info("Not on chat page, navigating...")
                     self.page.goto("https://chat.openai.com", wait_until="networkidle")
                     self.logger.info(f"Navigated to: {self.page.url}")


### PR DESCRIPTION
Potential fix for [https://github.com/EchoCog/echosurf2/security/code-scanning/3](https://github.com/EchoCog/echosurf2/security/code-scanning/3)

To fix the problem, we need to parse the URL and check the host value to ensure it matches the expected domain. This can be done using the `urlparse` function from the `urllib.parse` module. We will replace the `startswith` check with a more secure check that verifies the hostname.

1. Import the `urlparse` function from the `urllib.parse` module.
2. Parse the URL using `urlparse`.
3. Check if the hostname of the parsed URL matches the expected hostname (`chat.openai.com`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
