### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/test_auth.py
+++ b/test_auth.py
@@ -66,7 +66,6 @@ def main():
         # Authenticate each service
         for service_name, config in services.items():
             if any(config['credentials'].values()):  # Only try if we have credentials
-                logging.info(f"Authenticating {service_name}...")
                 success = browser.authenticate_service(
                     service_name,
                     config['container'],


### PR DESCRIPTION
Potential fix for [https://github.com/EchoCog/echosurf2/security/code-scanning/1](https://github.com/EchoCog/echosurf2/security/code-scanning/1)

To fix the problem, we need to ensure that no sensitive information is logged. The best way to do this is to avoid logging any part of the `services` dictionary that might contain sensitive data. Instead, we can log generic messages that do not include any potentially sensitive information.

Specifically, we should:
1. Remove the logging statement on line 69 that logs the service name.
2. Ensure that any logging statements do not include sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
