### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/selenium_interface.py
+++ b/selenium_interface.py
@@ -39,7 +39,8 @@ class SeleniumInterface:
                     browser = self.playwright.chromium.connect_over_cdp(f"http://localhost:{port}")
                     for context in browser.contexts:
                         for page in context.pages:
-                            if "chatgpt.com" in page.url:
+                            parsed_url = urlparse(page.url)
+                            if parsed_url.hostname and parsed_url.hostname.endswith("chatgpt.com"):
                                 self.browser = browser
                                 self.page = page
                                 self.logger.info(f"Connected to existing ChatGPT session on port {port}")


### PR DESCRIPTION
Potential fix for [https://github.com/EchoCog/echosurf2/security/code-scanning/2](https://github.com/EchoCog/echosurf2/security/code-scanning/2)

To fix the problem, we need to replace the substring check with a more secure method that parses the URL and checks the hostname. Specifically, we will use the `urlparse` function from the `urllib.parse` module to extract the hostname from the URL and then check if it matches the intended domain.

- Parse the URL using `urlparse`.
- Extract the hostname from the parsed URL.
- Check if the hostname ends with the intended domain (e.g., "chatgpt.com").


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
