### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/selenium_interface.py
+++ b/selenium_interface.py
@@ -40,7 +40,7 @@ class SeleniumInterface:
                     for context in browser.contexts:
                         for page in context.pages:
                             parsed_url = urlparse(page.url)
-                            if parsed_url.hostname and parsed_url.hostname.endswith("chatgpt.com"):
+                            if parsed_url.hostname and (parsed_url.hostname == "chatgpt.com" or parsed_url.hostname.endswith(".chatgpt.com")):
                                 self.browser = browser
                                 self.page = page
                                 self.logger.info(f"Connected to existing ChatGPT session on port {port}")


### PR DESCRIPTION
Potential fix for [https://github.com/EchoCog/echosurf2/security/code-scanning/4](https://github.com/EchoCog/echosurf2/security/code-scanning/4)

To fix the problem, we need to ensure that the hostname check correctly handles subdomains and does not allow arbitrary hostnames that end with "chatgpt.com". We can achieve this by ensuring the hostname ends with ".chatgpt.com" or is exactly "chatgpt.com".

- Parse the URL using `urlparse`.
- Check if the hostname ends with ".chatgpt.com" or is exactly "chatgpt.com".
- Update the code in the `find_existing_browser` method to implement this check.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
